### PR TITLE
プライバシーポリシーのルーティングの処理修正

### DIFF
--- a/router.js
+++ b/router.js
@@ -80,8 +80,9 @@ router.get('/privacy-policy', (req, res) => {
   res.sendFile(__dirname + '/public/PrivacyPolicy.html');
 })
 
+// モバイル側で対応できたら削除する
 router.get('/PrivacyPolicy', (req, res) => {
-  res.sendFile(__dirname + '/public/PrivacyPolicy.html');
+  res.redirect('/privacy-policy')
 })
 
 router.get('/how-to-setting', (req, res) => {

--- a/router.js
+++ b/router.js
@@ -80,6 +80,10 @@ router.get('/privacy-policy', (req, res) => {
   res.sendFile(__dirname + '/public/PrivacyPolicy.html');
 })
 
+router.get('/PrivacyPolicy', (req, res) => {
+  res.sendFile(__dirname + '/public/PrivacyPolicy.html');
+})
+
 router.get('/how-to-setting', (req, res) => {
   res.sendFile(__dirname + '/public/HowToSetting.html');
 })


### PR DESCRIPTION
アプリ側で埋め込んでいるリンクが`/PrivacyPolicy`のままになっていたのでそちらを`/privacy-policy`に修正しなければならないのですが、他のブランチとの競合などで着手するまでに時間がかかりそうなので、リダイレクトする処理を加えました。

一旦取り込んで頂けると幸いです。